### PR TITLE
Fixed DeckDefinitionLoader bugs

### DIFF
--- a/PlayLib/Utils/DeckDefinitionLoader.cs
+++ b/PlayLib/Utils/DeckDefinitionLoader.cs
@@ -1,17 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using CrazyEights.PlayLib.Data;
+using CrazyEights.PlayLib.Enums;
 
 namespace CrazyEights.PlayLib.Utils
 {
+    public class CardDataJsonConverter : JsonConverter<CardData>
+    {
+        public override CardData Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var validProperties = new HashSet<string>();
+            validProperties.Add("effectId");
+            validProperties.Add("effectArgs");
+            validProperties.Add("maxBaseCopies");
+            validProperties.Add("maxExtendedCopies");
+            var values = new List<JsonElement>(4);
+            using (var jsonDoc = JsonDocument.ParseValue(ref reader))
+            {
+                var properties = jsonDoc.RootElement.EnumerateObject().ToArray();
+
+                if (properties.Length != 4)
+                {
+                    throw new InvalidOperationException(
+                        "Error deserializing: Card Data has invalid number of properties"
+                    );
+                }
+
+                foreach (var property in properties)
+                {
+                    if (validProperties.Contains(property.Name))
+                    {
+                        validProperties.Remove(property.Name);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(
+                            $"Error deserializing: {property} is not a valid Card Data property"
+                        );
+                    }
+                }
+
+                return new CardData(
+                    (Effects)jsonDoc.RootElement.GetProperty("effectId").GetInt32(),
+                    jsonDoc.RootElement.GetProperty("effectArgs").GetInt32(),
+                    jsonDoc.RootElement.GetProperty("maxBaseCopies").GetInt32(),
+                    jsonDoc.RootElement.GetProperty("maxExtendedCopies").GetInt32()
+                );
+            }
+
+            throw new InvalidOperationException("Can't deserialize card data");
+        }
+
+        public override void Write(Utf8JsonWriter writer, CardData value, JsonSerializerOptions options)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+
     public static class DeckDefinitionLoader
     {
         public static T Load<T>(string jsonString) where T : DeckDefinition
         {
             var options = new JsonSerializerOptions
             {
+                MaxDepth = 3,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
+
+            options.Converters.Add(new CardDataJsonConverter());
 
             var cards = JsonSerializer.Deserialize<T>(jsonString, options);
             return cards;

--- a/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardData.json
+++ b/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardData.json
@@ -1,0 +1,10 @@
+{
+    "suits": [
+        {
+            "effectId": 0,
+            "maxBaseCopies": 1,
+            "maxExtendedCopies": 2
+        }
+    ],
+    "wilds": []
+}

--- a/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardDataDuplicatedProperties.json
+++ b/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardDataDuplicatedProperties.json
@@ -1,0 +1,11 @@
+{
+    "suits": [
+        {
+            "effectId": 0,
+            "maxBaseCopies": 1,
+            "maxBaseCopies": 1,
+            "maxExtendedCopies": 2
+        }
+    ],
+    "wilds": []
+}

--- a/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardDataExtraProperties.json
+++ b/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardDataExtraProperties.json
@@ -1,0 +1,12 @@
+{
+    "suits": [
+        {
+            "effectId": 0,
+            "effectArgs": 0,
+            "maxBaseCopies": 1,
+            "maxExtendedCopies": 2,
+            "something here": "invalid"
+        }
+    ],
+    "wilds": []
+}

--- a/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardDataWrongProperties.json
+++ b/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidCardDataWrongProperties.json
@@ -1,0 +1,11 @@
+{
+    "suits": [
+        {
+            "effectId": 0,
+            "wrongProperty": 0,
+            "maxBaseCopies": 1,
+            "maxExtendedCopies": 2
+        }
+    ],
+    "wilds": []
+}

--- a/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidEffectId.json
+++ b/ServerTests/PlayLib/TestAssets/DeckDefinitions/invalidEffectId.json
@@ -1,7 +1,7 @@
 {
     "suits": [
         {
-            "effectId": -1,
+            "effectId": "invalid",
             "effectArgs": 0,
             "maxBaseCopies": 1,
             "maxExtendedCopies": 2

--- a/ServerTests/PlayLib/Utils/DeckDefinitionLoaderTests.cs
+++ b/ServerTests/PlayLib/Utils/DeckDefinitionLoaderTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using CrazyEights.PlayLib.Data;
 using CrazyEights.PlayLib.Utils;
 
@@ -47,6 +49,58 @@ namespace CrazyEights.Tests.PlayLib.Utils
             );
         }
 
+        [Test, Description("Throws when loading invalid Card Data")]
+        public void DeckDefinitionLoader_Load_InvalidCardData()
+        {
+            var deckPath = "./Assets/DeckDefinitions/invalidCardData.json";
+            Assert.That(File.Exists(deckPath), Is.True, "Asset File Exists");
+            var jsonString = File.ReadAllText(deckPath);
+            Assert.That(
+                () => DeckDefinitionLoader.Load<DeckDefinition>(jsonString),
+                Throws.Exception,
+                "Should throw if card data is invalid"
+            );
+        }
+
+        [Test, Description("Throws when loading Card Data with duplicated properties")]
+        public void DeckDefinitionLoader_Load_InvalidCardData_DuplicatedProperties()
+        {
+            var deckPath = "./Assets/DeckDefinitions/invalidCardDataDuplicatedProperties.json";
+            Assert.That(File.Exists(deckPath), Is.True, "Asset File Exists");
+            var jsonString = File.ReadAllText(deckPath);
+            Assert.That(
+                () => DeckDefinitionLoader.Load<DeckDefinition>(jsonString),
+                Throws.Exception,
+                "Should throw if card data has duplicated properties"
+            );
+        }
+
+        [Test, Description("Throws when loading Card Data with extra properties")]
+        public void DeckDefinitionLoader_Load_InvalidCardData_ExtraProperties()
+        {
+            var deckPath = "./Assets/DeckDefinitions/invalidCardDataExtraProperties.json";
+            Assert.That(File.Exists(deckPath), Is.True, "Asset File Exists");
+            var jsonString = File.ReadAllText(deckPath);
+            Assert.That(
+                () => DeckDefinitionLoader.Load<DeckDefinition>(jsonString),
+                Throws.Exception,
+                "Should throw if card data has extra properties"
+            );
+        }
+
+        [Test, Description("Throws when loading Card Data with wrong properties")]
+        public void DeckDefinitionLoader_Load_InvalidCardData_WrongProperties()
+        {
+            var deckPath = "./Assets/DeckDefinitions/invalidCardDataWrongProperties.json";
+            Assert.That(File.Exists(deckPath), Is.True, "Asset File Exists");
+            var jsonString = File.ReadAllText(deckPath);
+            Assert.That(
+                () => DeckDefinitionLoader.Load<DeckDefinition>(jsonString),
+                Throws.Exception,
+                "Should throw if card data has invalid properties"
+            );
+        }
+
         [Test, Description("Throws when loading an invalid Deck Definition Json")]
         public void DeckDefinitionLoader_Load_InvalidDeck()
         {
@@ -56,7 +110,7 @@ namespace CrazyEights.Tests.PlayLib.Utils
             Assert.That(
                 () => DeckDefinitionLoader.Load<DeckDefinition>(jsonString),
                 Throws.Exception,
-                "Discard Pile must be initialized with a card count greater than zero"
+                "Should throw if deck definition is invalid"
             );
         }
 
@@ -68,7 +122,7 @@ namespace CrazyEights.Tests.PlayLib.Utils
             var jsonString = File.ReadAllText(deckPath);
             Assert.That(
                 () => DeckDefinitionLoader.Load<DeckDefinition>(jsonString),
-                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("effectId"),
+                Throws.TypeOf<JsonException>(),
                 "Deck definition must have valid Effect Ids"
             );
         }

--- a/ServerTests/ServerTests.csproj
+++ b/ServerTests/ServerTests.csproj
@@ -22,6 +22,22 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include=".\PlayLib\TestAssets\DeckDefinitions\invalidCardData.json">
+      <Link>Assets\DeckDefinitions\invalidCardData.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include=".\PlayLib\TestAssets\DeckDefinitions\invalidCardDataDuplicatedProperties.json">
+      <Link>Assets\DeckDefinitions\invalidCardDataDuplicatedProperties.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include=".\PlayLib\TestAssets\DeckDefinitions\invalidCardDataExtraProperties.json">
+      <Link>Assets\DeckDefinitions\invalidCardDataExtraProperties.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include=".\PlayLib\TestAssets\DeckDefinitions\invalidCardDataWrongProperties.json">
+      <Link>Assets\DeckDefinitions\invalidCardDataWrongProperties.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include=".\PlayLib\TestAssets\DeckDefinitions\invalidDeck.json">
       <Link>Assets\DeckDefinitions\invalidDeck.json</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
It loaded effects Id and Args with default value of 0 if they were missing. A custom converter was added to handle:

* Missing Properties
* Duplicated Properties
* Unknown Properties